### PR TITLE
Update Auth0 OIDC library to 2.4.0 from 2.0.0

### DIFF
--- a/Samples/Forms/FormsSample/FormsSample.Android/FormsSample.Android.csproj
+++ b/Samples/Forms/FormsSample/FormsSample.Android/FormsSample.Android.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Auth0.OidcClient.Android">
-      <Version>2.0.0</Version>
+      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="25.4.0.2" />

--- a/Samples/Forms/FormsSample/FormsSample.iOS/FormsSample.iOS.csproj
+++ b/Samples/Forms/FormsSample/FormsSample.iOS/FormsSample.iOS.csproj
@@ -153,7 +153,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Auth0.OidcClient.iOS">
-      <Version>2.0.0</Version>
+      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
   </ItemGroup>


### PR DESCRIPTION
Updates the OIDC library to the latest published version on NuGet (2.4.0)