### PR TITLE
Update Xamarin.Android.Suppport from 25 to 28

### DIFF
--- a/Samples/Forms/FormsSample/FormsSample.Android/FormsSample.Android.csproj
+++ b/Samples/Forms/FormsSample/FormsSample.Android/FormsSample.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -52,11 +52,11 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="25.4.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="25.4.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="25.4.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="25.4.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="25.4.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/Samples/Forms/FormsSample/FormsSample.Android/Properties/AndroidManifest.xml
+++ b/Samples/Forms/FormsSample/FormsSample.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.auth0.FormsSample" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="25" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<application android:label="FormsSample.Android"></application>
 </manifest>

--- a/Samples/Forms/FormsSample/FormsSample.Android/Resources/Resource.designer.cs
+++ b/Samples/Forms/FormsSample/FormsSample.Android/Resources/Resource.designer.cs
@@ -3640,7 +3640,10 @@ namespace FormsSample.Droid
 			public const int icon = 2130903040;
 			
 			// aapt resource value: 0x7f030001
-			public const int launcher_foreground = 2130903041;
+			public const int icon_round = 2130903041;
+			
+			// aapt resource value: 0x7f030002
+			public const int launcher_foreground = 2130903042;
 			
 			static Mipmap()
 			{


### PR DESCRIPTION
Updates the Xamarin Android support libraries to the latest version. Also requires bumping TargetFrameworkVersion to v8.1 (Oreo) and target SDK 27.