### PR TITLE
Bumped Auth0.OidcClient.Android to 3.1.3

### DIFF
--- a/Quickstart/01-Login/Android/AndroidSample/AndroidSample.csproj
+++ b/Quickstart/01-Login/Android/AndroidSample/AndroidSample.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Auth0.OidcClient.Android">
-      <Version>2.4.0</Version>
+      <Version>3.1.3</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
       <Version>28.0.0.1</Version>


### PR DESCRIPTION
### Description

This PR bumped `Auth0.OidcClient.Android` to 3.1.3 to gain access to a fix for passwordless flows, where the user would not be in the same state after closing their app to go and get the access code from another app.

### Type of change

- [X] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

Tested manually in the emulator using a passwordless flow, by verifying the issue then upgrading the library.

### Additional info

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
