### PR TITLE
Pass 'this' to Auth0Client constructor second argument

### DIFF
--- a/Quickstart/01-Login/Android/AndroidSample/MainActivity.cs
+++ b/Quickstart/01-Login/Android/AndroidSample/MainActivity.cs
@@ -34,7 +34,7 @@ namespace AndroidSample
                 Domain = GetString(Resource.String.auth0_domain),
                 ClientId = GetString(Resource.String.auth0_client_id),
                 Scope = "openid profile email"
-            });
+            }, this);
 
             SetContentView(Resource.Layout.Main);
             FindViewById<Button>(Resource.Id.LoginButton).Click += LoginButtonOnClick;


### PR DESCRIPTION
### Description

This PR adds `this` to the second argument of the `Auth0Client` constructor, which is now available after the 3.1.3 update to Auth0.OidcClient.Android library.

This allows Auth0Client to automatically read the IntentFilter on your Activity and determine the correct callback uri to use ([more](https://auth0.github.io/auth0-oidc-client-net/documentation/migration/v3.html#android))


### Additional info

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
