### PR TITLE
Update URLs to point to auth0-samples

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -48,7 +48,7 @@
   ],
   "contributorsPerLine": 7,
   "projectName": "auth0-xamarin-oidc-samples",
-  "projectOwner": "auth0-community",
+  "projectOwner": "auth0-samples",
   "repoType": "github",
   "repoHost": "https://github.com"
 }

--- a/Quickstart/01-Login/Android/README.md
+++ b/Quickstart/01-Login/Android/README.md
@@ -141,19 +141,19 @@ userDetailsTextView.Text = sb.ToString();
 
 ## Contribute
 
-Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md).
+Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md).
 
-Here you can also find the [PR template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
+Here you can also find the [PR template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
 
 ## Issues Reporting
 
-Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md#issues)!
+Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md#issues)!
 
-Here you can also find the [Issue template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
+Here you can also find the [Issue template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
 
 ## Repo Community
 
-Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-community-oss-auth0-xamarin-oidc-samples/15973)
+Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-samples-oss-auth0-xamarin-oidc-samples/15973)
 
 <a href="https://community.auth0.com/">
 <img src="/Assets/join_auth0_community_badge.png"/>
@@ -161,7 +161,7 @@ Feel like PRs and issues are not enough? Want to dive into further discussion ab
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
 
 ## What is Auth0?
 

--- a/Quickstart/01-Login/iOS/README.md
+++ b/Quickstart/01-Login/iOS/README.md
@@ -130,19 +130,19 @@ return true;
 
 ## Contribute
 
-Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md).
+Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md).
 
-Here you can also find the [PR template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
+Here you can also find the [PR template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
 
 ## Issues Reporting
 
-Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md#issues)!
+Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md#issues)!
 
-Here you can also find the [Issue template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
+Here you can also find the [Issue template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
 
 ## Repo Community
 
-Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-community-oss-auth0-xamarin-oidc-samples/15973)
+Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-samples-oss-auth0-xamarin-oidc-samples/15973)
 
 <a href="https://community.auth0.com/">
 <img src="/Assets/join_auth0_community_badge.png"/>
@@ -150,7 +150,7 @@ Feel like PRs and issues are not enough? Want to dive into further discussion ab
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
 
 ## What is Auth0?
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Thanks goes to these wonderful people who contribute(d) or maintain(ed) this rep
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://twitter.com/beardaway"><img src="https://avatars3.githubusercontent.com/u/11062800?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Conrad Sopala</b></sub></a><br /><a href="#maintenance-beardaway" title="Maintenance">🚧</a> <a href="https://github.com/auth0-community/auth0-xamarin-oidc-samples/pulls?q=is%3Apr+reviewed-by%3Abeardaway" title="Reviewed Pull Requests">👀</a></td>
-    <td align="center"><a href="https://damieng.com"><img src="https://avatars3.githubusercontent.com/u/118951?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Damien Guard</b></sub></a><br /><a href="#maintenance-damieng" title="Maintenance">🚧</a> <a href="https://github.com/auth0-community/auth0-xamarin-oidc-samples/commits?author=damieng" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/alexisluque"><img src="https://avatars2.githubusercontent.com/u/30907012?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Luque</b></sub></a><br /><a href="https://github.com/auth0-community/auth0-xamarin-oidc-samples/commits?author=alexisluque" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/frederikprijck"><img src="https://avatars.githubusercontent.com/u/2146903?s=460&v=4?s=100" width="100px;" alt=""/><br /><sub><b>Frederik Prijck</b></sub></a><br /><a href="https://github.com/auth0-community/auth0-xamarin-oidc-samples/commits?author=frederikprijck" title="Code">💻</a> <a href="#maintenance-frederikprijck" title="Maintenance">🚧</a> <a href="https://github.com/auth0-community/auth0-xamarin-oidc-samples/pulls?q=is%3Apr+reviewed-by%3Afrederikprijck" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://twitter.com/beardaway"><img src="https://avatars3.githubusercontent.com/u/11062800?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Conrad Sopala</b></sub></a><br /><a href="#maintenance-beardaway" title="Maintenance">🚧</a> <a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/pulls?q=is%3Apr+reviewed-by%3Abeardaway" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://damieng.com"><img src="https://avatars3.githubusercontent.com/u/118951?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Damien Guard</b></sub></a><br /><a href="#maintenance-damieng" title="Maintenance">🚧</a> <a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/commits?author=damieng" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/alexisluque"><img src="https://avatars2.githubusercontent.com/u/30907012?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Luque</b></sub></a><br /><a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/commits?author=alexisluque" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/frederikprijck"><img src="https://avatars.githubusercontent.com/u/2146903?s=460&v=4?s=100" width="100px;" alt=""/><br /><sub><b>Frederik Prijck</b></sub></a><br /><a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/commits?author=frederikprijck" title="Code">💻</a> <a href="#maintenance-frederikprijck" title="Maintenance">🚧</a> <a href="https://github.com/auth0-samples/auth0-xamarin-oidc-samples/pulls?q=is%3Apr+reviewed-by%3Afrederikprijck" title="Reviewed Pull Requests">👀</a></td>
   </tr>
 </table>
 
@@ -33,19 +33,19 @@ This repo is supported and maintained by Community Developers, not Auth0. For mo
 
 ## Contribute
 
-Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md).
+Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md).
 
-Here you can also find the [PR template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
+Here you can also find the [PR template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
 
 ## Issues Reporting
 
-Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md#issues)!
+Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md#issues)!
 
-Here you can also find the [Issue template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
+Here you can also find the [Issue template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
 
 ## Repo Community
 
-Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-community-oss-auth0-xamarin-oidc-samples/15973)
+Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-samples-oss-auth0-xamarin-oidc-samples/15973)
 
 <a href="https://community.auth0.com/">
 <img src="/Assets/join_auth0_community_badge.png"/>
@@ -53,7 +53,7 @@ Feel like PRs and issues are not enough? Want to dive into further discussion ab
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
 
 ## What is Auth0?
 

--- a/Samples/Forms_NS/readme.md
+++ b/Samples/Forms_NS/readme.md
@@ -61,19 +61,19 @@ var loginResult = await authenticationService.Authenticate();
 
 ## Contribute
 
-Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md).
+Feel like contributing to this repo? We're glad to hear that! Before you start contributing please visit our [Contributing Guideline](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md).
 
-Here you can also find the [PR template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
+Here you can also find the [PR template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/PULL_REQUEST_TEMPLATE.md) to fill once creating a PR. It will automatically appear once you open a pull request.
 
 ## Issues Reporting
 
-Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-community/getting-started/blob/master/CONTRIBUTION.md#issues)!
+Spotted a bug or any other kind of issue? We're just humans and we're always waiting for constructive feedback! Check our section on how to [report issues](https://github.com/auth0-samples/getting-started/blob/master/CONTRIBUTION.md#issues)!
 
-Here you can also find the [Issue template](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
+Here you can also find the [Issue template](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/ISSUE_TEMPLATE.md) to fill once opening a new issue. It will automatically appear once you create an issue.
 
 ## Repo Community
 
-Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-community-oss-auth0-xamarin-oidc-samples/15973)
+Feel like PRs and issues are not enough? Want to dive into further discussion about the tool? We created topics for each Auth0 Community repo so that you can join discussion on stack available on our repos. Here it is for this one: [auth0-xamarin-oidc-samples](https://community.auth0.com/t/auth0-samples-oss-auth0-xamarin-oidc-samples/15973)
 
 <a href="https://community.auth0.com/">
 <img src="/Assets/join_auth0_community_badge.png"/>
@@ -81,7 +81,7 @@ Feel like PRs and issues are not enough? Want to dive into further discussion ab
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-community/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0-samples/auth0-xamarin-oidc-samples/blob/master/LICENSE) file for more info.
 
 ## What is Auth0?
 


### PR DESCRIPTION
### Changes

- Update URLs to point to `auth0-samples`

### Internal References

- [SDK-5959](https://auth0team.atlassian.net/browse/SDK-5959)
- [SEC-4620](https://auth0team.atlassian.net/browse/SEC-4620)

### Type of change

- [x] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)
